### PR TITLE
Resolving missing points at the last buffer

### DIFF
--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -372,7 +372,7 @@ sinc_mono_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 	terminate = 1.0 / src_ratio + 1e-20 ;
 
 	/* Main processing loop. */
-	while (filter->out_gen < filter->out_count)
+	while (1)
 	{
 		/* Need to reload buffer? */
 		samples_in_hand = (filter->b_end - filter->b_current + filter->b_len) % filter->b_len ;


### PR DESCRIPTION
When src_process is called multiple times with a connected set of buffers, the last input data with the size of half_filter_chan_len is not processed. In other words, you will lose the last half_filter_chan_len points of data (which was 47 samples when I tried with SRC_SINC_MEDIUM_QUALITY). This is because the while loop on line 375 in src_sinc.c breaks when filter->out_gen equals filter->out_count. Logically it makes sense, except that it should further generate output (half_filter_chan_len points more) for the very last buffer, because the processing of the very first buffer was done for filter->out_count MINUS half_filter_chan_len. 

To resolve this issue, I am simply changing line 375 to `while (1)` and let the separate termination check do the work (lines 390 and 393).  And I am making sure, in my application, to allocate the data_out buffer big enough to absorb this in addition to the expected output buffer size.

The same logic should apply to other functions--`sinc_stereo_vari_process, sinc_quad_vari_process, sinc_hex_vari_process`, and `sinc_multichan_vari_process`, but I'm not using them and I can't check this issue in these functions. I would let others do it. But this change works well for my application, [auxlab](https://github.com/bjkwon/auxlab), so I'm using my own hacked version of libsamplerate for [auxlab](https://github.com/bjkwon/auxlab) for now (as of 3/20/2019).

The easiest way to replicate the issue is the following:
```
float * buffer_in = (float*)calloc(sizeof(float), 10000); // input buffer size is 10000 points
float * buffer_out = (float*)calloc(sizeof(float), 10000); // output is the same size; testing src_ratio = 1
// prepare the buffer
int errcode;
SRC_STATE* handle = src_new(SRC_SINC_MEDIUM_QUALITY, 1, &errcode);
SRC_DATA data;
data.src_ratio = 1;
data.data_in = buffer_in;
data.data_out = buffer_out;
data.input_frames = 5000; // half the buffer
data.output_frames = 5000; 
data.end_of_input = 0; 
errcode = src_process(handle, &data); // processing the first half
//after the call, 
//data.input_frames_used was 5000 but
//data.output_frames_gen was 4953, which is 5000 minus half_filter_chan_len in src_sinc.c
data.data_in = buffer_in + data.input_frames_used ;
data.data_out = buffer_out + data.output_frames_gen;
data.end_of_input = 1; 
errcode = src_process(handle, &data); // processing the second half
//Now you get 
//data.input_frames_used would be still 5000 (i.e., all input buffer has been read)
//data.output_frames_gen would be 5000. And, this is not right. We should have gotten 5047 points.
```

This hack will get you all the output data, without missing the last 47 points. 
Hope this helps.